### PR TITLE
Добавляет CompanyShortSerializer, меняет ListAutoServiceSerializer

### DIFF
--- a/api/v1/autoservice/serializers.py
+++ b/api/v1/autoservice/serializers.py
@@ -37,6 +37,19 @@ class CompanySerializer(serializers.ModelSerializer):
         ]
 
 
+class CompanyShortSerializer(serializers.ModelSerializer):
+    """
+    Сериализатор для компаний автосервисов (с укороченным набором полей).
+    """
+    class Meta:
+        model = Company
+        fields = [
+            'id',
+            'title',
+            'logo',
+        ]
+
+
 class GeolocationAutoServiceSerializer(serializers.ModelSerializer):
     """
     Сериализатор для геолокации автосервиса.
@@ -99,11 +112,10 @@ class ListAutoServiceSerializer(serializers.ModelSerializer):
     """
     Сериализатор для списка автосервисов.
     """
-    company = CompanySerializer()
+    company = CompanyShortSerializer()
     geolocation = GeolocationAutoServiceSerializer()
     rating = serializers.FloatField(read_only=True)
     votes = serializers.IntegerField(read_only=True)
-    working_time = WorkTimeSerializer()
 
     class Meta:
         model = AutoService
@@ -114,7 +126,7 @@ class ListAutoServiceSerializer(serializers.ModelSerializer):
             'address',
             'rating',
             'votes',
-            'working_time',
+            'working_time_text',
         ]
 
 
@@ -158,19 +170,24 @@ class AutoServiceSerializer(serializers.ModelSerializer):
         job = AutoserviceJob.objects.filter(service=obj)
         return AutoserviceJobSerializer(job, many=True).data
 
+
 class ImageSerializer(serializers.ModelSerializer):
+
     class Meta:
         model = Image
         fields = ['id', 'image']
+
 
 class FeedbackSerializer(serializers.ModelSerializer):
     """
     Сериализатор для модели Feedback.
     """
     # поле для изображений
-    images = ImageSerializer(many=True,required=False,help_text='Загрузите изображение (необязательно)')#read_only=True)
-
-
+    images = ImageSerializer(
+        many=True,
+        required=False,
+        help_text='Загрузите изображение (необязательно)'
+    )
     author = serializers.SlugRelatedField(
         read_only=True,
         slug_field='email',
@@ -206,6 +223,7 @@ class FeedbackSerializer(serializers.ModelSerializer):
 
 class JobsSerializer(serializers.ModelSerializer):
     """Сериализатор для работ автосервиса"""
+
     class Meta:
         model = Job
         fields = "__all__"

--- a/core/management/commands/import_autoservice.py
+++ b/core/management/commands/import_autoservice.py
@@ -163,21 +163,27 @@ class Command(BaseCommand):
             if not value[3]:
                 value[3] = 'Москва'
             if value[9]:
+                working_time_text = ''
+                for day, time in value[9].items():
+                    working_time_text += f'{day}: {time}<br>'
                 avtoservice, created = AutoService.objects.get_or_create(
                     company=company,
                     address=value[3],
                     geolocation=geolocation,
                     city=City.objects.get(id=2),
                     working_time=workingtime,
+                    working_time_text=working_time_text,
                     phone_number=phone_number,
                     site=value[4]
                 )
             else:
+                working_time_text = 'Неуказано время работы'
                 avtoservice, created = AutoService.objects.get_or_create(
                     company=company,
                     address=value[3],
                     geolocation=geolocation,
                     city=City.objects.get(id=2),
+                    working_time_text=working_time_text,
                     phone_number=phone_number,
                     site=value[4]
                 )


### PR DESCRIPTION
Для решения проблемы долгой загрузки сайта на главной странице:
Фронты запрашивают все автосервисы и выводят 3 лучших,
- вместо сложной передачи (связанных таблиц) информации об днях и времени работы автосервиса, будем отдавать дни и время работы каждого автосервиса одной строкой вида:
"working_time_text": "Понедельник: 09:00 – 21:00<br>Вторник: 09:00 – 21:00<br>Среда: 09:00 – 21:00<br>Четверг: 09:00 – 21:00<br>Пятница: 09:00 – 21:00<br>Суббота: 09:00 – 21:00<br>Воскресенье: 09:00 – 21:00<br>"
(если фронтам не понравится сама строка, можно ее будет переделать, под их хотелки)
Так же сократили кол-во передаваемых полей для списка автосервисов (Добавили CompanyShortSerializer, изменили ListAutoServiceSerializer)
Сейчас при тестировании постманом urla на отдачу всех автосервисов у меня на компьютере:
- старый вариант - 10 секунд
- новый вариант - 1 секунда
На сервере будет по хуже, но надеюсь это не будут прежние 20-25 секунд.

