### PR TITLE
fix: set file upload max memory size to 25 Mb

### DIFF
--- a/car_service/settings.py
+++ b/car_service/settings.py
@@ -233,3 +233,6 @@ NUMBER_WEEK = {
     5: 'Суббота',
     6: 'Воскресенье',
 }
+
+# File upload settints
+FILE_UPLOAD_MAX_MEMORY_SIZE = 26214400


### PR DESCRIPTION
Теперь до 25 мб файлы грузятся нормально. В будущем нужно разобраться почему временное сохранение на диск вызывает проблемы.