### PR TITLE
Добавил поле autoservice_name в get запросы на списки order

### DIFF
--- a/api/v1/order/serializers.py
+++ b/api/v1/order/serializers.py
@@ -13,6 +13,7 @@ class OrderImagesSerializer(serializers.ModelSerializer):
 
 
 class OrderSerializer(serializers.ModelSerializer):
+    аutoservice_name = serializers.SerializerMethodField()
 
     def __init__(self, *args, **kwargs):
         file_fields = kwargs.pop("file_fields", None)
@@ -35,6 +36,10 @@ class OrderSerializer(serializers.ModelSerializer):
         for file in validated_files:
             OrderImages.objects.create(order=order_instance, file=file)
         return order_instance
+
+    def get_аutoservice_name(self, obj: Order) -> str:
+        autoservice_name = obj.autoservice.company.title
+        return autoservice_name
 
     class Meta:
         model = Order

--- a/api/v1/order/tests/test_current_user_view.py
+++ b/api/v1/order/tests/test_current_user_view.py
@@ -25,7 +25,7 @@ test_order = {
     "status": "OPENED",
     "company": "Сотта",
     "phone_number": "+79633114455",
-    "number_of_fields": 9,
+    "number_of_fields": 10,
 }
 
 another_user = {
@@ -73,6 +73,11 @@ class TestGetAllFieldsFromOrderListAPIView(TestCase):
     def test_current_user_list_api_view_get_all_fields(self):
         number_of_current_user_orders = 1
         self.assertEqual(number_of_current_user_orders, len(self.response.data))
+
+    def test_list_api_view_get_autoservice_name(self):
+        self.assertEqual(
+            test_order["company"], self.response.data[0]["аutoservice_name"]
+        )
 
 
 class TestPostCurrentUserOrderListAPIView(TestCase):

--- a/api/v1/order/tests/test_current_user_view.py
+++ b/api/v1/order/tests/test_current_user_view.py
@@ -65,15 +65,14 @@ class TestGetAllFieldsFromOrderListAPIView(TestCase):
 
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
+        self.response = self.client.get("/api/v1/orders/me/", format="json")
 
     def test_current_user_list_api_view_get_status_code_200(self):
-        response = self.client.get("/api/v1/orders/me/", format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.response.status_code, status.HTTP_200_OK)
 
     def test_current_user_list_api_view_get_all_fields(self):
         number_of_current_user_orders = 1
-        response = self.client.get("/api/v1/orders/me/", format="json")
-        self.assertEqual(number_of_current_user_orders, len(response.data))
+        self.assertEqual(number_of_current_user_orders, len(self.response.data))
 
 
 class TestPostCurrentUserOrderListAPIView(TestCase):

--- a/api/v1/order/tests/test_order_view.py
+++ b/api/v1/order/tests/test_order_view.py
@@ -21,7 +21,7 @@ test_order = {
     "status": "OPENED",
     "company": "Сотта",
     "phone_number": "+79633114454",
-    "number_of_fields": 9,
+    "number_of_fields": 10,
 }
 
 
@@ -50,3 +50,7 @@ class TestGetAllFieldsFromOrderListAPIView(TestCase):
     def test_list_api_view_get_all_fields(self):
         self.assertEqual(test_order["number_of_fields"], len(self.response.data[0]))
 
+    def test_list_api_view_get_autoservice_name(self):
+        self.assertEqual(
+            test_order["company"], self.response.data[0]["аutoservice_name"]
+        )

--- a/api/v1/order/tests/test_order_view.py
+++ b/api/v1/order/tests/test_order_view.py
@@ -42,11 +42,11 @@ class TestGetAllFieldsFromOrderListAPIView(TestCase):
 
         self.client = APIClient()
         self.client.force_authenticate(user=self.user)
+        self.response = self.client.get("/api/v1/orders/", format="json")
 
     def test_list_api_view_get_status_code_200(self):
-        response = self.client.get("/api/v1/orders/", format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.response.status_code, status.HTTP_200_OK)
 
     def test_list_api_view_get_all_fields(self):
-        response = self.client.get("/api/v1/orders/", format="json")
-        self.assertEqual(test_order["number_of_fields"], len(response.data[0]))
+        self.assertEqual(test_order["number_of_fields"], len(self.response.data[0]))
+


### PR DESCRIPTION
При вызове get на `orders/` и `orders/me/` возвращается объект с дополнительным полем `autoservice_name`.

Добавил тесты для проверки что поле существует и имеет значение после вызова get.