### PR TITLE
fix: issue #140 set allow all to CORS if DEVELOPMENT True

### DIFF
--- a/car_service/settings.py
+++ b/car_service/settings.py
@@ -51,7 +51,8 @@ MIDDLEWARE = [
 ]
 
 CORS_ORIGIN_ALLOW_ALL = True
-CORS_URLS_REGEX = r'^/api/.*$'
+if DEVELOPMENT is False:
+    CORS_URLS_REGEX = r'^/api/.*$'
 
 ROOT_URLCONF = 'car_service.urls'
 


### PR DESCRIPTION
Если переменная DEVELOPMENT True, то отключается настройка CORS_URLS_REGEX. Это позволяет делать CORS запросы на любой API в режиме DEVELOPMENT.

closes #140 